### PR TITLE
Fix donor data integrity and add donation details

### DIFF
--- a/src/common/components/organisms/DonorModal.jsx
+++ b/src/common/components/organisms/DonorModal.jsx
@@ -51,11 +51,6 @@ const inputStyle = {
   boxSizing: 'border-box',
 };
 
-const selectStyle = {
-  ...inputStyle,
-  cursor: 'pointer',
-};
-
 const row = {
   display: 'flex',
   justifyContent: 'flex-end',
@@ -95,9 +90,6 @@ const EMPTY = {
   email: '',
   address: '',
   phone: '',
-  total_donations: '',
-  donation_count: '',
-  most_recent: '',
 };
 
 /** Empty / whitespace-only → null so JSON has explicit null (SQL NULL), not omitted undefined. */
@@ -107,18 +99,6 @@ function nullIfEmptyStr(value) {
   return s === '' ? null : s;
 }
 
-function nullIfEmptyFloat(value) {
-  if (value == null || value === '') return null;
-  const n = parseFloat(value);
-  return Number.isFinite(n) ? n : null;
-}
-
-function nullIfEmptyInt(value) {
-  if (value == null || value === '') return null;
-  const n = parseInt(String(value), 10);
-  return Number.isFinite(n) ? n : null;
-}
-
 function toFormValues(donor) {
   if (!donor) return { ...EMPTY };
   return {
@@ -126,9 +106,6 @@ function toFormValues(donor) {
     email: donor.email ?? '',
     address: donor.address ?? '',
     phone: donor.phone ?? '',
-    total_donations: donor.total_donations ?? '',
-    donation_count: donor.donation_count ?? '',
-    most_recent: donor.most_recent?.slice(0, 10) ?? '',
   };
 }
 
@@ -158,9 +135,6 @@ export default function DonorModal({ open, onClose, onSubmit, donor }) {
         email: form.email.trim(),
         address: nullIfEmptyStr(form.address),
         phone: nullIfEmptyStr(form.phone),
-        total_donations: nullIfEmptyFloat(form.total_donations),
-        donation_count: nullIfEmptyInt(form.donation_count),
-        most_recent: nullIfEmptyStr(form.most_recent),
       });
       onClose();
     } catch (err) {
@@ -218,40 +192,6 @@ export default function DonorModal({ open, onClose, onSubmit, donor }) {
             type='tel'
             value={form.phone}
             onChange={set('phone')}
-          />
-        </div>
-
-        <div style={fieldGroup}>
-          <label style={labelStyle}>Total Donation Amount ($)</label>
-          <input
-            style={inputStyle}
-            type='number'
-            step='0.01'
-            min='0'
-            value={form.total_donations}
-            onChange={set('total_donations')}
-          />
-        </div>
-
-        <div style={fieldGroup}>
-          <label style={labelStyle}>Donation Count</label>
-          <input
-            style={inputStyle}
-            type='number'
-            step='1'
-            min='0'
-            value={form.donation_count}
-            onChange={set('donation_count')}
-          />
-        </div>
-
-        <div style={fieldGroup}>
-          <label style={labelStyle}>Most Recent Donation Date</label>
-          <input
-            style={inputStyle}
-            type='date'
-            value={form.most_recent}
-            onChange={set('most_recent')}
           />
         </div>
 

--- a/src/common/components/organisms/DonorsTable.jsx
+++ b/src/common/components/organisms/DonorsTable.jsx
@@ -29,7 +29,7 @@ const COLUMNS = [
   { label: 'Address' },
   { label: 'Phone' },
   { label: 'Total Donations', style: { textAlign: 'center' } },
-  { label: 'Donation Count' },
+  { label: 'Donation Count', style: { textAlign: 'center' } },
   { label: 'Most Recent' },
   { label: 'Actions' },
 ];
@@ -112,7 +112,7 @@ export default function DonorTable({
               <td style={tdStyle}>{addressCell(d)}</td>
               <td style={tdStyle}>{d.phone}</td>
               <td style={{ ...tdStyle, textAlign: 'center' }}>{formatAmount(d.total_donations)}</td>
-              <td style={tdStyle}>{d.donation_count}</td>
+              <td style={{ ...tdStyle, textAlign: 'center' }}>{d.donation_count}</td>
               <td style={tdStyle}>{formatDate(d.most_recent)}</td>
               <td style={tdStyle} onClick={(e) => e.stopPropagation()}>
                 <ActionsMenu

--- a/src/common/components/organisms/DonorsTable.jsx
+++ b/src/common/components/organisms/DonorsTable.jsx
@@ -24,14 +24,14 @@ const checkboxTd = {
 /* ── DonorTable ───────────────────────────────────── */
 
 const COLUMNS = [
-  'Name',
-  'Email',
-  'Address',
-  'Phone',
-  'Total Donations',
-  'Donation Count',
-  'Most Recent',
-  'Actions',
+  { label: 'Name' },
+  { label: 'Email' },
+  { label: 'Address' },
+  { label: 'Phone' },
+  { label: 'Total Donations', style: { textAlign: 'center' } },
+  { label: 'Donation Count' },
+  { label: 'Most Recent' },
+  { label: 'Actions' },
 ];
 
 function addressCell(d) {
@@ -77,9 +77,9 @@ export default function DonorTable({
               onChange={(e) => onSelectAll(e.target.checked)}
             />
           </th>
-          {COLUMNS.map((h) => (
-            <th key={h} style={thStyle}>
-              {h}
+          {COLUMNS.map(({ label, style }) => (
+            <th key={label} style={{ ...thStyle, ...style }}>
+              {label}
             </th>
           ))}
         </tr>
@@ -111,7 +111,7 @@ export default function DonorTable({
               <td style={tdStyle}>{d.email}</td>
               <td style={tdStyle}>{addressCell(d)}</td>
               <td style={tdStyle}>{d.phone}</td>
-              <td style={tdStyle}>{formatAmount(d.total_donations)}</td>
+              <td style={{ ...tdStyle, textAlign: 'center' }}>{formatAmount(d.total_donations)}</td>
               <td style={tdStyle}>{d.donation_count}</td>
               <td style={tdStyle}>{formatDate(d.most_recent)}</td>
               <td style={tdStyle} onClick={(e) => e.stopPropagation()}>

--- a/src/pages/donors/DonorEditModal.jsx
+++ b/src/pages/donors/DonorEditModal.jsx
@@ -105,12 +105,7 @@ export default function DonorEditModal({ open, onClose, onSubmit, donor }) {
     setSaving(true);
     setError(null);
     try {
-      await onSubmit({
-        ...form,
-        total_donations: donor?.total_donations ?? 0,
-        donation_count: donor?.donation_count ?? 0,
-        most_recent: donor?.most_recent?.slice(0, 10) ?? null,
-      });
+      await onSubmit({ ...form });
       onClose();
     } catch (err) {
       setError(err.message);

--- a/src/services/adminService.js
+++ b/src/services/adminService.js
@@ -12,7 +12,7 @@ async function authHeaders() {
 
 async function request(url, options = {}) {
   const headers = await authHeaders();
-  const res = await fetch(url, { ...options, headers });
+  const res = await fetch(url, { ...options, headers, credentials: 'include' });
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));

--- a/src/services/donorService.js
+++ b/src/services/donorService.js
@@ -44,33 +44,16 @@ function normalizeDonorsListPayload(raw) {
   return { donors, total };
 }
 
-/** Optional string fields: empty string / undefined → null for SQL-friendly JSON bodies. */
-const OPTIONAL_NULL_STRING_KEYS = ['address', 'phone', 'most_recent'];
-
 function normalizeDonorBody(data) {
   if (data == null || typeof data !== 'object') return data;
   const out = { ...data };
-  for (const key of OPTIONAL_NULL_STRING_KEYS) {
+  for (const key of ['address', 'phone']) {
     if (!(key in out)) continue;
     const v = out[key];
-    if (v === undefined || v === null) {
-      out[key] = null;
-    } else if (typeof v === 'string' && v.trim() === '') {
+    if (v === undefined || v === null || (typeof v === 'string' && v.trim() === '')) {
       out[key] = null;
     }
   }
-  const td = out.total_donations;
-  if (td === '' || td === undefined) out.total_donations = null;
-  else if (typeof td === 'number' && !Number.isFinite(td))
-    out.total_donations = null;
-
-  const dc = out.donation_count;
-  if (dc === '' || dc === undefined) out.donation_count = null;
-  else if (typeof dc === 'number' && !Number.isFinite(dc))
-    out.donation_count = null;
-  else if (typeof dc === 'string' && dc.trim() === '')
-    out.donation_count = null;
-
   return out;
 }
 


### PR DESCRIPTION
## Summary

- **Donor form data integrity** — removed `total_donations`, `donation_count`, and `most_recent` from the create/edit donor forms and their submit payloads. These are computed aggregates maintained server-side and should never be client-writable. Cleaned up `normalizeDonorBody` in `donorService` accordingly.

- **Admin user fetch fix** — added `credentials: 'include'` to `adminService` requests to match the rest of the app and fix CORS failures on the `/auth/users` endpoint.

- **Donors table UI** — centered the "Total Donations" and "Donation Count" columns.

- **Donation details** — clicking a donation now opens a detail view modal. Phone and address fields are shown as read-only. Removed duplicate `ChartsRow`, `RecentDonations`, and `StatsRow` from the donations page and reused existing shared components.

- **Auth persistence** — users stay logged in after a page refresh.

- **Bug fix** — resolved a chart syntax error that caused a crash on the dashboard.

## Test plan

- [ ] Create a new donor — confirm `total_donations`, `donation_count`, `most_recent` fields are gone from the form
- [ ] Edit a donor's contact info — confirm those fields are not sent in the PUT request (check Network tab)
- [ ] Open Admin page — confirm users load without a CORS error
- [ ] Donors table — confirm "Total Donations" and "Donation Count" are centered
- [ ] Click a donation row — confirm detail modal opens with correct data
- [ ] Refresh the page while logged in — confirm session is preserved
- [ ] Open the dashboard — confirm charts render without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)