### PR TITLE
fix: bump Stripe sync client timeout from 30s to 5min

### DIFF
--- a/src/pages/dashboard/index.jsx
+++ b/src/pages/dashboard/index.jsx
@@ -116,7 +116,10 @@ export default function DashboardPage() {
 
   const handleSyncStripe = async () => {
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 30_000);
+    // 5 min — Stripe sync can take a while when pulling full history (e.g. first
+    // run after a truncate). Backend-side processing governs the real deadline;
+    // this just prevents the request from hanging indefinitely on network issues.
+    const timeoutId = setTimeout(() => controller.abort(), 5 * 60 * 1000);
     setSyncing(true);
     try {
       const {


### PR DESCRIPTION
## Problem

After triggering \`Refresh Stripe\` on the dashboard, users see a \"Sync failed\" toast — but a page refresh reveals the new data is actually there.

The \`handleSyncStripe\` handler has an \`AbortController\` set to abort after 30s. The initial Stripe sync (especially after a table truncate or on first deploy) takes longer than that to pull the full payment intent history, so the client aborts before the backend finishes. Backend keeps going and persists everything; user just sees the stale error toast.

## Fix

Bump the timeout from 30s to 5min. This is generous enough for a from-scratch sync of years of donation history; the backend's own processing time still governs the real deadline.

## Test plan

- [ ] Click Refresh Stripe with empty tables → succeeds without timeout toast
- [ ] Click Refresh Stripe on a populated DB → behaves the same as before (returns quickly)