### PR TITLE
fix: prevent DB dates from shifting back a day in browser display

### DIFF
--- a/src/pages/donors/DonorStatsRow.jsx
+++ b/src/pages/donors/DonorStatsRow.jsx
@@ -15,6 +15,7 @@ function formatMemberSince(date) {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
+    timeZone: 'UTC',
   });
 }
 

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,8 +1,14 @@
 export function formatDate(dateStr) {
+  // The backend stores donation_date as a DATE (YYYY-MM-DD) in the
+  // foundation's local timezone (America/Chicago). `new Date("2026-05-19")`
+  // parses as UTC midnight; toLocaleDateString in the browser's local TZ
+  // (e.g., Central) then shifts to the previous day. Format as UTC so the
+  // date renders exactly as stored.
   return new Date(dateStr).toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+    timeZone: 'UTC',
   });
 }
 


### PR DESCRIPTION
## Problem

User notices the dashboard shows the most recent donation as **May 18**, but the database actually has donations through May 19.

The DB stores \`donation_date\` as a plain \`DATE\` (\`YYYY-MM-DD\`) in the foundation's local timezone. The frontend then does:

\`\`\`js
new Date(dateStr).toLocaleDateString('en-US', { ... })
\`\`\`

\`new Date("2026-05-19")\` parses as **UTC midnight**, then \`toLocaleDateString\` renders in the browser's local timezone. For anyone west of UTC (Central = UTC-5/6), midnight UTC rolls back to ~7pm the previous day — displaying as **May 18**.

## Fix

Pass \`timeZone: 'UTC'\` to \`toLocaleDateString\` so it formats the date exactly as stored, with no shift.

Applied to:
- \`src/utils/format.js\` → \`formatDate\` (donation rows, table, etc.)
- \`src/pages/donors/DonorStatsRow.jsx\` → \`formatMemberSince\`

## Test plan

- [ ] Dashboard "Recent Donations" shows the same date as the DB (max should be \`2026-05-19\` per current data)
- [ ] Donation detail modal shows the correct date
- [ ] Donor profile "Member since" shows the correct date