### PR TITLE
Add admin-only Docs tab and revamp handoff docs

### DIFF
--- a/src/common/components/atoms/NavItem.jsx
+++ b/src/common/components/atoms/NavItem.jsx
@@ -7,6 +7,8 @@
     - icon (elementType): The icon to display.
     - active (boolean): Whether the item is active.
     - onClick (function): The function to call when the item is clicked.
+    - href (string): When provided, renders an anchor link (e.g. for the docs
+      site served outside the SPA) instead of a button.
 */
 import PropTypes from 'prop-types';
 
@@ -28,7 +30,21 @@ const btnStyle = (active) => ({
   marginBottom: '2px',
 });
 
-export default function NavItem({ label, icon: Icon, active, onClick }) {
+export default function NavItem({ label, icon: Icon, active, onClick, href }) {
+  if (href) {
+    return (
+      <a
+        href={href}
+        target='_blank'
+        rel='noopener noreferrer'
+        style={{ ...btnStyle(active), textDecoration: 'none' }}
+      >
+        <Icon size={16} strokeWidth={active ? 2.2 : 1.8} />
+        {label}
+      </a>
+    );
+  }
+
   return (
     <button style={btnStyle(active)} onClick={onClick}>
       <Icon size={16} strokeWidth={active ? 2.2 : 1.8} />
@@ -42,9 +58,11 @@ NavItem.propTypes = {
   icon: PropTypes.elementType.isRequired,
   active: PropTypes.bool,
   onClick: PropTypes.func,
+  href: PropTypes.string,
 };
 
 NavItem.defaultProps = {
   active: false,
   onClick: undefined,
+  href: undefined,
 };

--- a/src/common/components/organisms/Sidebar.jsx
+++ b/src/common/components/organisms/Sidebar.jsx
@@ -11,14 +11,21 @@ import { useNavigate } from 'react-router-dom';
 import NavItem from '@/common/components/atoms/NavItem';
 import UserProfile from '@/common/components/molecules/UserProfile';
 import { useUser } from '@/common/contexts/UserContext';
-import { DollarSign, LayoutDashboard, ShieldCheck, Users } from 'lucide-react';
+import {
+  BookOpen,
+  DollarSign,
+  LayoutDashboard,
+  ShieldCheck,
+  Users,
+} from 'lucide-react';
 import PropTypes from 'prop-types';
 
 const NAV_ITEMS = [
   { label: 'Dashboard', icon: LayoutDashboard, id: 'dashboard' },
   { label: 'Donations', icon: DollarSign, id: 'donations' },
   { label: 'Donors', icon: Users, id: 'donors' },
-  { label: 'Admin', icon: ShieldCheck, id: 'admin' },
+  { label: 'Admin', icon: ShieldCheck, id: 'admin', adminOnly: true },
+  { label: 'Docs', icon: BookOpen, href: '/docs/', adminOnly: true },
 ];
 
 const styles = {
@@ -64,7 +71,7 @@ function getDisplayName(user) {
 export default function Sidebar({ activePage, onNavigate }) {
   const { user, logout } = useUser();
   const navItems = NAV_ITEMS.filter(
-    ({ id }) => id !== 'admin' || user?.role === 'admin'
+    ({ adminOnly }) => !adminOnly || user?.role === 'admin'
   );
   const navigate = useNavigate();
 
@@ -83,13 +90,14 @@ export default function Sidebar({ activePage, onNavigate }) {
         />
       </div>
       <nav style={styles.nav}>
-        {navItems.map(({ label, icon, id }) => (
+        {navItems.map(({ label, icon, id, href }) => (
           <NavItem
-            key={id}
+            key={id || href}
             label={label}
             icon={icon}
-            active={activePage === id}
-            onClick={() => onNavigate && onNavigate(id)}
+            href={href}
+            active={!href && activePage === id}
+            onClick={href ? undefined : () => onNavigate && onNavigate(id)}
           />
         ))}
       </nav>

--- a/website/docs/handoff/next-steps.mdx
+++ b/website/docs/handoff/next-steps.mdx
@@ -4,9 +4,13 @@ sidebar_position: 3
 
 # Next Steps
 
+Priority-ranked work for the incoming team. See [Progress](./progress) for what
+is already done and the [Handoff overview](./overview) to orient first.
+
 ## High priority
 
-1. Add request/response examples for all externally used backend endpoints.
+1. Add request/response examples for all externally used backend endpoints
+   (extends [Backend endpoints](../reference/backend-endpoints)).
 2. Add an environment matrix (`dev`, `staging`, `prod`) for both frontend/backend.
 3. Document rollback procedure for frontend and backend deployments.
 4. Define and enforce test gates for merge/deploy.

--- a/website/docs/handoff/overview.mdx
+++ b/website/docs/handoff/overview.mdx
@@ -2,25 +2,112 @@
 sidebar_position: 1
 ---
 
-# Overview
+# Handoff
 
-This handoff section is for future maintainers of the C&W Market Foundation donor management system.
+**Start here.** This is the entry point for any new maintainer of the C&W
+Market Foundation donor management system. It explains what you are inheriting,
+how to get the system running, and links out to every other section you need to
+work on the project.
 
-## Scope
+If you only read one page before touching the code, read this one — then follow
+the links below.
 
-- Frontend app (`cwd-frontend`)
-- Backend API (`cwd-backend`)
-- Documentation site (`cwd-frontend/website`)
+## What you're inheriting
+
+The product is split across two application repositories plus a documentation
+site that builds into the frontend:
+
+| Component | Location | Stack | Deploys to |
+|-----------|----------|-------|------------|
+| Frontend SPA | `cwd-frontend` | React 19, Vite, React Router v7, styled-components, Firebase Auth | Firebase Hosting |
+| Backend API | `cwd-backend` | Node.js, Express, Firebase Admin, MySQL/PostgreSQL | AWS EC2 |
+| Docs site | `cwd-frontend/website` | Docusaurus | Served at `/docs` on the frontend host |
+
+External dependencies the system relies on: **Firebase** (auth + hosting),
+**AWS** (EC2, RDS, Secrets Manager), and **Resend** (transactional email). See
+[Deployment Overview](../deployment/overview) for how they fit together.
+
+For the product goals and full capability list, see the
+[Introduction](/).
+
+## Get the system running
+
+Work through [Getting Started](../getting-started) in order — it covers the
+frontend, backend, and docs site running together locally:
+
+1. [Prerequisites](../getting-started/prerequisites) — Node.js 20+, npm, Git,
+   plus a Firebase project and a running backend.
+2. [Installation](../getting-started/installation) — clone and install
+   dependencies for each service.
+3. [Environment variables](../getting-started/environment-variables) — copy each
+   `.env.example` and fill in `VITE_BACKEND_URL` and the `VITE_FIREBASE_*` keys.
+4. [Running locally](../getting-started/running-locally) — start backend
+   (`:5050`), frontend (`:5173`), and docs (`:3000`).
+
+The single most common local failure is auth: make sure backend CORS allows your
+Vite origin and that both services point at the **same Firebase project**. The
+[Running locally troubleshooting table](../getting-started/running-locally#troubleshooting)
+covers the rest.
+
+## Learn the system
+
+Read these before making non-trivial changes:
+
+- **[Authentication](../authentication)** — the hybrid Firebase + backend auth
+  model, login lifecycle, and the `pending` / `member` / `admin` role behavior.
+  This underpins nearly every route and API call.
+- **Frontend** — [project structure](../frontend/project-structure),
+  [website layout](../frontend/website-layout), and
+  [features](../frontend/features). Follow the conventions in
+  `cwd-frontend/CLAUDE.md` (atomic component hierarchy, `@/` path alias,
+  200-line file limit, styled-components only).
+- **Backend** — [project structure](../backend/project-structure) and
+  [implementation](../backend/implementation). The API is layered
+  `routes → middleware → controllers → repositories → providers`.
+- **Reference** — [backend endpoints](../reference/backend-endpoints) (the
+  contract the frontend expects) and the
+  [source layout](../reference/source-layout) map.
+
+## Operate & deploy
+
+Both apps deploy automatically on push to `main`. Before you ship anything:
+
+- **[Deployment Overview](../deployment/overview)** — the two-repo / two-platform
+  topology and the architecture diagram.
+- **[AWS](../deployment/aws)** — backend infrastructure (EC2, RDS, Secrets
+  Manager, CDK in `cwd-backend/infra`).
+- **[AWS Operations](../deployment/aws-operations)** — day-2 runbook: manual
+  deploys, domain/SSL, restarts.
+- **[Firebase](../deployment/firebase)** — hosting + auth setup and the GitHub
+  deploy integration.
+- **[Resend](../deployment/resend)** — transactional email (donation receipts).
+
+:::warning Secrets are not edited by hand
+The backend production `.env` is rewritten on every deploy by
+`scripts/fetch-secrets.sh` pulling from AWS Secrets Manager. Edit the secret in
+Secrets Manager, not the file. Never commit any `.env`.
+:::
+
+## Project status
+
+- **[Progress](./progress)** — what is complete, in progress, and the known
+  gaps.
+- **[Next Steps](./next-steps)** — priority-ranked tasks for the incoming team.
 
 ## Goals of this handoff
 
-- Reduce onboarding time for the next team
-- Preserve architecture and deployment intent
-- Make current implementation status explicit
+- Reduce onboarding time for the next team.
+- Preserve architecture and deployment intent.
+- Make current implementation status explicit.
 
 ## Suggested handoff package
 
-- Latest working branch + deployment notes
-- Environment variable templates for both services
-- Known risks, bugs, and technical debt list
-- Priority-ranked next tasks (see [Next Steps](./next-steps))
+When transferring ownership, hand over:
+
+- Latest working branch + deployment notes.
+- Environment variable templates for both services (see
+  [Environment variables](../getting-started/environment-variables)).
+- Access to Firebase, AWS, and Resend accounts, plus the GitHub Actions secrets
+  listed in [Deployment Overview](../deployment/overview).
+- Known risks, bugs, and technical debt list (see [Progress](./progress)).
+- Priority-ranked next tasks (see [Next Steps](./next-steps)).

--- a/website/docs/handoff/progress.mdx
+++ b/website/docs/handoff/progress.mdx
@@ -4,6 +4,10 @@ sidebar_position: 2
 
 # Progress
 
+Current implementation status. For where to take the project next, see
+[Next Steps](./next-steps); for the system entry point, see the
+[Handoff overview](./overview).
+
 ## Completed
 
 - Frontend route framework and guarded navigation

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -14,6 +14,13 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
  */
 const sidebars: SidebarsConfig = {
   tutorialSidebar: [
+    {
+      type: 'category',
+      label: 'Handoff Documentation',
+      collapsible: true,
+      collapsed: false,
+      items: ['handoff/overview', 'handoff/progress', 'handoff/next-steps'],
+    },
     'intro',
     {
       type: 'category',
@@ -59,13 +66,6 @@ const sidebars: SidebarsConfig = {
         'deployment/firebase',
         'deployment/resend',
       ],
-    },
-    {
-      type: 'category',
-      label: 'Handoff Documentation',
-      collapsible: true,
-      collapsed: false,
-      items: ['handoff/overview', 'handoff/progress', 'handoff/next-steps'],
     },
   ],
 };


### PR DESCRIPTION
## Summary

Two related changes to surface and improve the project documentation:

### Admin-only Docs tab
- Adds a **Docs** item to the app sidebar linking to the Docusaurus site at `/docs/`, visible **only to admin users**.
- Generalizes the sidebar's admin gate into a reusable `adminOnly` flag (applied to both Admin and Docs items).
- Extends `NavItem` with an optional `href` prop: when set it renders a styled anchor (opens in a new tab) instead of a router button, since the docs are served outside the React Router SPA.

### Handoff docs revamp
- Moves the **Handoff** section to the top of the docs sidebar.
- Rewrites `handoff/overview.mdx` into a self-contained, hyperlinked onboarding entry point (what you're inheriting, how to run it, what to read, how to deploy, project status) linking to Getting Started, Authentication, Frontend/Backend, Deployment, and Reference docs.
- Cross-links `progress.mdx` and `next-steps.mdx`.

## Testing
- `npx prettier --check` on changed files — clean.
- `npm run test` — 20/20 pass.
- `npm run build` (docs site, `onBrokenLinks: throw`) — succeeds with no broken links.

> Note: the Docs link resolves against a host that serves `/docs/` (deployed Firebase Hosting), matching the Docusaurus `baseUrl`. In local frontend dev the docs site runs separately on `:3000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)